### PR TITLE
fixed drawing modded items

### DIFF
--- a/UI/CustomItemSlot.cs
+++ b/UI/CustomItemSlot.cs
@@ -8,6 +8,7 @@ using Terraria.GameContent.Achievements;
 using Terraria.GameInput;
 using Terraria.ID;
 using Terraria.Localization;
+using Terraria.ModLoader;
 using Terraria.UI;
 using Terraria.UI.Chat;
 
@@ -180,7 +181,8 @@ namespace CustomSlot.UI {
             float itemLightScale = 1f;
 
             if(Item.stack > 0) {
-                itemTexture = Main.Assets.Request<Texture2D>(TextureAssets.Item[Item.type].Name).Value;
+                Main.instance.LoadItem(Item.type);
+                itemTexture = TextureAssets.Item[Item.type].Value;
                 itemRectangle = Main.itemAnimations[Item.type] != null ?
                     Main.itemAnimations[Item.type].GetFrame(itemTexture) : itemTexture.Frame();
                 color = Color.White;

--- a/UI/CustomItemSlot.cs
+++ b/UI/CustomItemSlot.cs
@@ -147,10 +147,13 @@ namespace CustomSlot.UI {
                         ItemChanged?.Invoke(this, new ItemChangedEventArgs(tempItem, Item));
                     }
                     else {
+                        if(Main.playerInventory) // check if inv is open or not so interaction with slot doesnt happen by accident
+                        {
                         ItemSlot.Handle(ref item, tempContext);
 
                         if(tempItem.type != Item.type)
                             ItemChanged?.Invoke(this, new ItemChangedEventArgs(tempItem, Item));
+                        }
                     }
 
                     if(!string.IsNullOrEmpty(HoverText)) {

--- a/UI/CustomItemSlot.cs
+++ b/UI/CustomItemSlot.cs
@@ -188,7 +188,11 @@ namespace CustomSlot.UI
                 }
             }
         }
-
+        public void SetPos(float X, float Y)
+        {
+            Left.Set(X, 0);
+            Top.Set(Y, 0);
+        }
         /// <summary>
         /// Set the item in the slot.
         /// </summary>

--- a/UI/CustomItemSlot.cs
+++ b/UI/CustomItemSlot.cs
@@ -12,15 +12,19 @@ using Terraria.ModLoader;
 using Terraria.UI;
 using Terraria.UI.Chat;
 
-namespace CustomSlot.UI {
-    public class CustomItemSlot : UIElement {
-        public enum ArmorType {
+namespace CustomSlot.UI
+{
+    public class CustomItemSlot : UIElement
+    {
+        public enum ArmorType
+        {
             Head,
             Chest,
             Leg
         }
 
-        public static class DefaultColors {
+        public static class DefaultColors
+        {
             public static readonly Color EmptyTexture = Color.White * 0.35f;
             public static readonly Color InventoryItemBack = Main.inventoryBack;
             public static readonly Color EquipBack = Color.White * 0.8f;
@@ -48,6 +52,10 @@ namespace CustomSlot.UI {
         /// <summary>
         /// The text to display when the slot is hovered over.
         /// </summary>
+        public int? ItemRarity { get; set; }
+        /// <summary>
+        /// The text to display when the slot is hovered over.
+        /// </summary>
         public string HoverText { get; set; }
         /// <summary>
         /// A function to determine whether the mouse item can be placed in the slot.
@@ -68,9 +76,11 @@ namespace CustomSlot.UI {
         /// <summary>
         /// The scale of the slot.
         /// </summary>
-        public float Scale {
+        public float Scale
+        {
             get => scale;
-            set {
+            set
+            {
                 scale = value;
                 CalculateSize();
             }
@@ -78,9 +88,11 @@ namespace CustomSlot.UI {
         /// <summary>
         /// The background texture of the slot.
         /// </summary>
-        public CroppedTexture2D BackgroundTexture {
+        public CroppedTexture2D BackgroundTexture
+        {
             get => backgroundTexture;
-            set {
+            set
+            {
                 backgroundTexture = value;
                 CalculateSize();
             }
@@ -88,19 +100,23 @@ namespace CustomSlot.UI {
         /// <summary>
         /// Whether to force a toggle button on the slot if the context does not allow one.
         /// </summary>
-        public bool ForceToggleButton {
+        public bool ForceToggleButton
+        {
             get => forceToggleButton;
-            set {
+            set
+            {
                 forceToggleButton = value;
                 bool hasButton = forceToggleButton || HasToggleButton(Context);
 
-                if(!hasButton) {
-                    if(toggleButton == null) return;
+                if (!hasButton)
+                {
+                    if (toggleButton == null) return;
 
                     RemoveChild(toggleButton);
                     toggleButton = null;
                 }
-                else {
+                else
+                {
                     toggleButton = new ToggleVisibilityButton();
                     Append(toggleButton);
                 }
@@ -108,7 +124,8 @@ namespace CustomSlot.UI {
         }
 
         public CustomItemSlot(int context = ItemSlot.Context.InventoryItem, float scale = 1f,
-            ArmorType defaultArmorIcon = ArmorType.Head) {
+            ArmorType defaultArmorIcon = ArmorType.Head)
+        {
             Context = context;
             this.scale = scale;
             backgroundTexture = GetBackgroundTexture(context);
@@ -122,42 +139,51 @@ namespace CustomSlot.UI {
             CalculateSize();
         }
 
-        protected override void DrawSelf(SpriteBatch spriteBatch) {
+        protected override void DrawSelf(SpriteBatch spriteBatch)
+        {
             DoDraw(spriteBatch);
 
-            if(ContainsPoint(Main.MouseScreen) && !PlayerInput.IgnoreMouseInterface) {
-                Main.LocalPlayer.mouseInterface = true;
+            if (ContainsPoint(Main.MouseScreen) && !PlayerInput.IgnoreMouseInterface)
+            {
+                if (Main.playerInventory)
+                {
+                    Main.LocalPlayer.mouseInterface = true;
+                }
+                if (toggleButton != null && toggleButton.ContainsPoint(Main.MouseScreen)) return;
 
-                if(toggleButton != null && toggleButton.ContainsPoint(Main.MouseScreen)) return;
-
-                if(Main.mouseItem.IsAir || IsValidItem == null || IsValidItem(Main.mouseItem)) {
+                if (Main.mouseItem.IsAir || IsValidItem == null || IsValidItem(Main.mouseItem))
+                {
                     int tempContext = Context;
                     Item tempItem = Item.Clone();
 
                     // fix if it's a vanity slot with no partner
-                    if(Main.mouseRightRelease && Main.mouseRight) {
-                        if(Context == ItemSlot.Context.EquipArmorVanity)
+                    if (Main.mouseRightRelease && Main.mouseRight)
+                    {
+                        if (Context == ItemSlot.Context.EquipArmorVanity)
                             tempContext = ItemSlot.Context.EquipArmor;
-                        else if(Context == ItemSlot.Context.EquipAccessoryVanity)
+                        else if (Context == ItemSlot.Context.EquipAccessoryVanity)
                             tempContext = ItemSlot.Context.EquipAccessory;
                     }
 
-                    if(Partner != null && Main.mouseRightRelease && Main.mouseRight) {
+                    if (Partner != null && Main.mouseRightRelease && Main.mouseRight)
+                    {
                         SwapWithPartner();
                         ItemChanged?.Invoke(this, new ItemChangedEventArgs(tempItem, Item));
                     }
-                    else {
-                        if(Main.playerInventory) // check if inv is open or not so interaction with slot doesnt happen by accident
+                    else
+                    {
+                        if (Main.playerInventory) // check if inv is open or not so interaction with slot doesnt happen by accident
                         {
-                        ItemSlot.Handle(ref item, tempContext);
+                            ItemSlot.Handle(ref item, tempContext);
 
-                        if(tempItem.type != Item.type)
-                            ItemChanged?.Invoke(this, new ItemChangedEventArgs(tempItem, Item));
+                            if (tempItem.type != Item.type)
+                                ItemChanged?.Invoke(this, new ItemChangedEventArgs(tempItem, Item));
                         }
                     }
 
-                    if(!string.IsNullOrEmpty(HoverText)) {
-                        Main.hoverItemName = HoverText;
+                    if (!string.IsNullOrEmpty(HoverText) && ItemRarity != null)
+                    {
+                        Main.instance.MouseText(cursorText: HoverText, rare: (int)ItemRarity);
                     }
                 }
             }
@@ -168,22 +194,25 @@ namespace CustomSlot.UI {
         /// </summary>
         /// <param name="newItem">item to put in the slot</param>
         /// <param name="fireItemChangedEvent">whether to fire the <see cref="ItemChanged"/> event</param>
-        public virtual void SetItem(Item newItem, bool fireItemChangedEvent = true) {
+        public virtual void SetItem(Item newItem, bool fireItemChangedEvent = true)
+        {
             Item tempItem = item.Clone();
             item = newItem.Clone();
 
-            if(fireItemChangedEvent)
+            if (fireItemChangedEvent)
                 ItemChanged?.Invoke(this, new ItemChangedEventArgs(tempItem, newItem));
         }
 
-        protected void DoDraw(SpriteBatch spriteBatch) {
+        protected void DoDraw(SpriteBatch spriteBatch)
+        {
             Rectangle rectangle = GetDimensions().ToRectangle();
             Texture2D itemTexture = EmptyTexture.Texture;
             Rectangle itemRectangle = EmptyTexture.Rectangle;
             Color color = EmptyTexture.Color;
             float itemLightScale = 1f;
 
-            if(Item.stack > 0) {
+            if (Item.stack > 0)
+            {
                 Main.instance.LoadItem(Item.type);
                 itemTexture = TextureAssets.Item[Item.type].Value;
                 itemRectangle = Main.itemAnimations[Item.type] != null ?
@@ -193,7 +222,8 @@ namespace CustomSlot.UI {
                 ItemSlot.GetItemLight(ref color, ref itemLightScale, Item);
             }
 
-            if(BackgroundTexture.Texture != null) {
+            if (BackgroundTexture.Texture != null)
+            {
                 spriteBatch.Draw(
                     BackgroundTexture.Texture,
                     rectangle.TopLeft(),
@@ -206,14 +236,18 @@ namespace CustomSlot.UI {
                     1f);
             }
 
-            if(itemTexture != null) {
+            if (itemTexture != null)
+            {
                 // copied from ItemSlot.Draw()
                 float oversizedScale = 1f;
-                if(itemRectangle.Width > 32 || itemRectangle.Height > 32) {
-                    if(itemRectangle.Width > itemRectangle.Height) {
+                if (itemRectangle.Width > 32 || itemRectangle.Height > 32)
+                {
+                    if (itemRectangle.Width > itemRectangle.Height)
+                    {
                         oversizedScale = 32f / itemRectangle.Width;
                     }
-                    else {
+                    else
+                    {
                         oversizedScale = 32f / itemRectangle.Height;
                     }
                 }
@@ -234,7 +268,8 @@ namespace CustomSlot.UI {
             }
 
             // position based on vanilla code
-            if(Item.stack > 1) {
+            if (Item.stack > 1)
+            {
                 ChatManager.DrawColorCodedStringWithShadow(
                     spriteBatch,
                     FontAssets.ItemStack.Value,
@@ -252,20 +287,24 @@ namespace CustomSlot.UI {
         /// <summary>
         /// Swap the current item with its partner slot.
         /// </summary>
-        protected void SwapWithPartner() {
+        protected void SwapWithPartner()
+        {
             // modified from vanilla code
             Utils.Swap(ref item, ref Partner.item);
             SoundEngine.PlaySound(SoundID.Grab);
             Recipe.FindRecipes();
 
-            if(Item.stack <= 0) return;
+            if (Item.stack <= 0) return;
 
-            if(Context != 0) {
-                if(Context - 8 <= 4 || Context - 16 <= 1) {
+            if (Context != 0)
+            {
+                if (Context - 8 <= 4 || Context - 16 <= 1)
+                {
                     AchievementsHelper.HandleOnEquip(Main.LocalPlayer, Item, Context);
                 }
             }
-            else {
+            else
+            {
                 AchievementsHelper.NotifyItemPickup(Main.LocalPlayer, Item);
             }
         }
@@ -273,8 +312,9 @@ namespace CustomSlot.UI {
         /// <summary>
         /// Calculate the size of the slot based on background texture and scale.
         /// </summary>
-        internal void CalculateSize() {
-            if(BackgroundTexture == CroppedTexture2D.Empty) return;
+        internal void CalculateSize()
+        {
+            if (BackgroundTexture == CroppedTexture2D.Empty) return;
 
             float width = BackgroundTexture.Texture.Width * Scale;
             float height = BackgroundTexture.Texture.Height * Scale;
@@ -283,22 +323,27 @@ namespace CustomSlot.UI {
             Height.Set(height, 0f);
         }
 
-        protected internal class ToggleVisibilityButton : UIElement {
-            internal ToggleVisibilityButton() {
+        protected internal class ToggleVisibilityButton : UIElement
+        {
+            internal ToggleVisibilityButton()
+            {
                 Width.Set(TextureAssets.InventoryTickOn.Value.Width, 0f);
                 Height.Set(TextureAssets.InventoryTickOn.Value.Height, 0f);
             }
 
-            protected override void DrawSelf(SpriteBatch spriteBatch) {
-                if(Parent is not CustomItemSlot slot) return;
+            protected override void DrawSelf(SpriteBatch spriteBatch)
+            {
+                if (Parent is not CustomItemSlot slot) return;
 
                 DoDraw(spriteBatch, slot);
 
-                if(ContainsPoint(Main.MouseScreen) && !PlayerInput.IgnoreMouseInterface) {
+                if (ContainsPoint(Main.MouseScreen) && !PlayerInput.IgnoreMouseInterface)
+                {
                     Main.LocalPlayer.mouseInterface = true;
                     Main.hoverItemName = Language.GetTextValue(slot.ItemVisible ? "LegacyInterface.59" : "LegacyInterface.60");
 
-                    if(Main.mouseLeftRelease && Main.mouseLeft) {
+                    if (Main.mouseLeftRelease && Main.mouseLeft)
+                    {
                         SoundEngine.PlaySound(SoundID.MenuTick);
                         slot.ItemVisible = !slot.ItemVisible;
                         slot.ItemVisibilityChanged?.Invoke(slot, new ItemVisibilityChangedEventArgs(slot.ItemVisible));
@@ -306,7 +351,8 @@ namespace CustomSlot.UI {
                 }
             }
 
-            protected void DoDraw(SpriteBatch spriteBatch, CustomItemSlot slot) {
+            protected void DoDraw(SpriteBatch spriteBatch, CustomItemSlot slot)
+            {
                 Rectangle parentRectangle = Parent.GetDimensions().ToRectangle();
                 Texture2D tickTexture =
                     slot.ItemVisible ? TextureAssets.InventoryTickOn.Value : TextureAssets.InventoryTickOff.Value;
@@ -326,11 +372,13 @@ namespace CustomSlot.UI {
         /// </summary>
         /// <param name="context">slot context</param>
         /// <returns>background texture of the slot</returns>
-        public static CroppedTexture2D GetBackgroundTexture(int context) {
+        public static CroppedTexture2D GetBackgroundTexture(int context)
+        {
             Texture2D texture;
             Color color = Main.inventoryBack;
 
-            switch(context) {
+            switch (context)
+            {
                 case ItemSlot.Context.EquipAccessory:
                 case ItemSlot.Context.EquipArmor:
                 case ItemSlot.Context.EquipGrapple:
@@ -386,12 +434,15 @@ namespace CustomSlot.UI {
         /// <param name="context">slot context</param>
         /// <param name="armorType">type of equipment in the slot</param>
         /// <returns>empty texture of the slot</returns>
-        public static CroppedTexture2D GetEmptyTexture(int context, ArmorType armorType = ArmorType.Head) {
+        public static CroppedTexture2D GetEmptyTexture(int context, ArmorType armorType = ArmorType.Head)
+        {
             int frame = -1;
 
-            switch(context) {
+            switch (context)
+            {
                 case ItemSlot.Context.EquipArmor:
-                    switch(armorType) {
+                    switch (armorType)
+                    {
                         case ArmorType.Head:
                             frame = 0;
                             break;
@@ -404,7 +455,8 @@ namespace CustomSlot.UI {
                     }
                     break;
                 case ItemSlot.Context.EquipArmorVanity:
-                    switch(armorType) {
+                    switch (armorType)
+                    {
                         case ArmorType.Head:
                             frame = 3;
                             break;
@@ -442,7 +494,7 @@ namespace CustomSlot.UI {
                     break;
             }
 
-            if(frame == -1) return CroppedTexture2D.Empty;
+            if (frame == -1) return CroppedTexture2D.Empty;
 
             Texture2D extraTextures = TextureAssets.Extra[54].Value;
             Rectangle rectangle = extraTextures.Frame(3, 6, frame % 3, frame / 3);
@@ -455,7 +507,8 @@ namespace CustomSlot.UI {
         /// <summary>
         /// Whether the slot has a visibility toggle button.
         /// </summary>
-        public static bool HasToggleButton(int context) {
+        public static bool HasToggleButton(int context)
+        {
             return context == ItemSlot.Context.EquipAccessory ||
                    context == ItemSlot.Context.EquipLight ||
                    context == ItemSlot.Context.EquipPet;


### PR DESCRIPTION
```itemTexture = Main.Assets.Request<Texture2D>(TextureAssets.Item[Item.type].Name).Value;```

getting modded item textures using Main.assets.* throws an exception, so i just directly used ```TextureAssets.Item[Item.type].Value``` to assign to ```itemTexture```, and added ```Main.instance.LoadItem(Item.type)``` before it to allow for that.

I don't know why there's so many changed lines, i may have added/removed a space. Just replace:
```itemTexture = Main.Assets.Request<Texture2D>(TextureAssets.Item[Item.type].Name).Value;``` in DoDraw()

with:
```Main.instance.LoadItem(Item.type);```
```itemTexture = TextureAssets.Item[Item.type].Value;```